### PR TITLE
Add automated heightmap setup tool

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,10 @@
+# Project Structure
+
+This repository contains the Terrain3D GDExtension for Godot 4. The top level directories are:
+
+- `src/` – C++ source code for the core extension.
+- `project/` – Godot project containing the addon.
+- `doc/` – documentation and build scripts.
+- `tools/` – helper shell/python scripts and git hooks.
+
+The addon itself lives in `project/addons/terrain_3d/`.

--- a/doc/docs/guided_setup.md
+++ b/doc/docs/guided_setup.md
@@ -1,0 +1,15 @@
+# Guided Terrain Setup
+
+`setup_tool.gd` provides a non-interactive method of importing a heightmap and generating a scene that uses Terrain3D.
+
+## Usage
+
+```
+$ godot --headless --path project --script addons/terrain_3d/tools/setup_tool.gd -- <heightmap_image> <data_directory> <scene_path>
+```
+
+- `heightmap_image` – path to an image file compatible with Terrain3D (e.g. `.exr`, `.png`, `.r16`).
+- `data_directory` – directory where the processed terrain data will be stored.
+- `scene_path` – location of the resulting `.tscn` scene.
+
+The tool loads the heightmap, creates terrain data, saves it to `data_directory` and packs a simple scene containing a `Terrain3D` node.

--- a/project/addons/terrain_3d/tools/setup_tool.gd
+++ b/project/addons/terrain_3d/tools/setup_tool.gd
@@ -1,0 +1,47 @@
+@tool
+extends Node
+
+# Command line tool to import a heightmap and generate a scene using Terrain3D.
+# Usage:
+#   godot --headless --path project --script addons/terrain_3d/tools/setup_tool.gd -- <heightmap> <data_dir> <scene.tscn>
+
+func _ready() -> void:
+    var args := OS.get_cmdline_user_args()
+    if args.size() < 3:
+        print("Usage: godot --headless --path project --script addons/terrain_3d/tools/setup_tool.gd -- <heightmap> <data_dir> <scene.tscn>")
+        get_tree().quit()
+        return
+    var heightmap_path := args[0]
+    var data_dir := args[1]
+    var scene_path := args[2]
+
+    var height_img: Image = Terrain3DUtil.load_image(heightmap_path, ResourceLoader.CACHE_MODE_IGNORE)
+    if height_img == null:
+        push_error("Failed to load heightmap: %s" % heightmap_path)
+        get_tree().quit()
+        return
+
+    var terrain := Terrain3D.new()
+    add_child(terrain)
+    terrain.material = Terrain3DMaterial.new()
+    terrain.assets = Terrain3DAssets.new()
+
+    var images := []
+    images.resize(Terrain3DRegion.TYPE_MAX)
+    images[Terrain3DRegion.TYPE_HEIGHT] = height_img
+    terrain.get_data().import_images(images, Vector3.ZERO)
+
+    DirAccess.make_dir_recursive_absolute(data_dir)
+    terrain.get_data().save_directory(data_dir)
+    terrain.data_directory = data_dir
+
+    var root := Node3D.new()
+    root.add_child(terrain)
+    var scene := PackedScene.new()
+    scene.pack(root)
+    var err := ResourceSaver.save(scene_path, scene)
+    if err != OK:
+        push_error("Failed to save scene: %s" % scene_path)
+    else:
+        print("Scene saved to %s" % scene_path)
+    get_tree().quit()


### PR DESCRIPTION
## Summary
- document repository structure
- add guided heightmap setup instructions
- implement `setup_tool.gd` for command-line heightmap import

## Testing
- `scons platform=linux` *(fails: missing SConscript / godot-cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6855b25473b08321af1aa0befc1e0f24